### PR TITLE
Add light theme to time picker

### DIFF
--- a/iOSUILib/iOSUILib/Calendar/MDCalendar.h
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendar.h
@@ -43,7 +43,7 @@ typedef NS_OPTIONS(NSInteger, MDCalendarCellState) {
   MDCalendarCellStateButton = 1 << 7
 };
 
-typedef NS_OPTIONS(NSInteger, MDCalendarTheme) {
+typedef NS_ENUM(NSInteger, MDCalendarTheme) {
   MDCalendarThemeLight = 1,
   MDCalendarThemeDark = 2
 };

--- a/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.h
+++ b/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.h
@@ -33,6 +33,7 @@
 @class MDButton;
 @interface MDDatePickerDialog : UIButton
 
+@property (nullable, strong, nonatomic) NSDate *selectedDate;
 @property(weak, nonatomic) id<MDDatePickerDialogDelegate> delegate;
 
 - (void)show;

--- a/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.h
+++ b/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.h
@@ -31,7 +31,7 @@
 @end
 
 @class MDButton;
-@interface MDDatePickerDialog : UIButton
+@interface MDDatePickerDialog : UIControl
 
 @property (nullable, strong, nonatomic) NSDate *selectedDate;
 @property(weak, nonatomic) id<MDDatePickerDialogDelegate> delegate;

--- a/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.m
+++ b/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.m
@@ -146,6 +146,16 @@
   return self;
 }
 
+-(NSDate*)selectedDate;
+{
+    return self.calendar.selectedDate;
+}
+
+-(void)setSelectedDate:(NSDate *)selectedDate;
+{
+    self.calendar.selectedDate = selectedDate;
+}
+
 -(void)setTitleOk: (nonnull NSString *) okTitle andTitleCancel: (nonnull NSString *) cancelTitle {
     _okTitle =  okTitle;
     _cancelTitle = cancelTitle;

--- a/iOSUILib/iOSUILib/Calendar/MDTimePickerDialog.h
+++ b/iOSUILib/iOSUILib/Calendar/MDTimePickerDialog.h
@@ -27,10 +27,16 @@
 
 @class MDTimePickerDialog;
 
-typedef NS_OPTIONS(NSInteger, MDCalendarTimeMode) {
+typedef NS_ENUM(NSInteger, MDCalendarTimeMode) {
   MDCalendarTimeMode12H,
   MDCalendarTimeMode24H
 };
+
+typedef NS_ENUM(NSInteger, MDTimePickerTheme) {
+    MDTimePickerThemeLight = 1,
+    MDTimePickerThemeDark,
+};
+
 
 NS_ASSUME_NONNULL_BEGIN
 @protocol MDTimePickerDialogDelegate <NSObject>
@@ -41,8 +47,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@class MDButton;
-@interface MDTimePickerDialog : UIButton <UIGestureRecognizerDelegate>
+@interface MDTimePickerDialog : UIControl
+
+/// note: these colors are set by the theme
+@property(nonatomic, strong) UIColor *titleColor;
+@property(nonatomic, strong) UIColor *titleSelectedColor;
+@property(nonatomic, strong) UIColor *headerTextColor;
+@property(nonatomic, strong) UIColor *headerBackgroundColor;
+@property(nonatomic, strong) UIColor *selectionColor;
+@property(nonatomic, strong) UIColor *selectionCenterColor;
+@property(nonatomic, strong) UIColor *backgroundPopupColor;
+@property(nonatomic, strong) UIColor *backgroundClockColor;
+
+@property(nonatomic, assign) MDTimePickerTheme theme;
 
 @property(nonatomic, weak) id<MDTimePickerDialogDelegate> delegate;
 

--- a/iOSUILibDemo/DatePickerDialogController.m
+++ b/iOSUILibDemo/DatePickerDialogController.m
@@ -47,8 +47,15 @@
 
 - (IBAction)btnSelectDate:(id)sender {
   if (!_datePicker) {
+    NSDateComponents *dateComponents = [[NSDateComponents alloc] init];
+    dateComponents.year = 1980;
+    dateComponents.month = 1;
+    dateComponents.day = 1;
+    NSDate *date = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
+      
     MDDatePickerDialog *datePicker = [[MDDatePickerDialog alloc] init];
     _datePicker = datePicker;
+    _datePicker.selectedDate = date;
     _datePicker.delegate = self;
   }
   [_datePicker show];

--- a/iOSUILibDemo/TimePickerDialogViewController.m
+++ b/iOSUILibDemo/TimePickerDialogViewController.m
@@ -29,8 +29,6 @@
 @property(weak, nonatomic) IBOutlet UITextField *txtTimerStart;
 @property(weak, nonatomic) IBOutlet UIButton *btnStartTime;
 @property(nonatomic) NSDateFormatter *dateFormatter;
-
-@property(nonatomic) MDTimePickerDialog *timerPicker;
 @end
 
 @implementation TimePickerDialogViewController

--- a/iOSUILibDemo/TimePickerDialogViewController.m
+++ b/iOSUILibDemo/TimePickerDialogViewController.m
@@ -28,6 +28,7 @@
 @interface TimePickerDialogViewController () <MDTimePickerDialogDelegate>
 @property(weak, nonatomic) IBOutlet UITextField *txtTimerStart;
 @property(weak, nonatomic) IBOutlet UIButton *btnStartTime;
+@property(weak, nonatomic) IBOutlet UISwitch *lightThemeSwitch;
 @property(nonatomic) NSDateFormatter *dateFormatter;
 @end
 
@@ -45,12 +46,14 @@
 }
 
 - (IBAction)btnSelectTime:(id)sender {
-  if (!_timerPicker) {
-    MDTimePickerDialog *timePicker = [[MDTimePickerDialog alloc] init];
-    _timerPicker = timePicker;
-    _timerPicker.delegate = self;
+  MDTimePickerDialog *timePicker = [[MDTimePickerDialog alloc] init];
+  if (self.lightThemeSwitch.on) {
+    timePicker.theme = MDTimePickerThemeLight;
+  } else {
+    timePicker.theme = MDTimePickerThemeDark;
   }
-  [_timerPicker show];
+  timePicker.delegate = self;
+  [timePicker show];
 }
 
 - (void)timePickerDialog:(MDTimePickerDialog *)timePickerDialog

--- a/iOSUILibDemo/TimePickerDialogViewController.xib
+++ b/iOSUILibDemo/TimePickerDialogViewController.xib
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TimePickerDialogViewController">
             <connections>
                 <outlet property="btnStartTime" destination="2jQ-R7-rgr" id="ojY-xt-gu3"/>
+                <outlet property="lightThemeSwitch" destination="1DK-GJ-0PR" id="KiP-YV-0t6"/>
                 <outlet property="timeTextField" destination="nZW-fM-tCV" id="WcO-ai-vpQ"/>
                 <outlet property="txtTimerStart" destination="nZW-fM-tCV" id="KVb-Jv-z9E"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -20,12 +21,14 @@
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timer Setting" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Kq-G0-zpH">
                     <rect key="frame" x="136" y="20" width="103" height="21"/>
+                    <animations/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2jQ-R7-rgr">
                     <rect key="frame" x="312" y="58" width="43" height="30"/>
+                    <animations/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="G4f-Js-yo2"/>
                         <constraint firstAttribute="width" constant="43" id="hlt-Oz-UsF"/>
@@ -39,16 +42,18 @@
                 </button>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nZW-fM-tCV">
                     <rect key="frame" x="70" y="58" width="202" height="30"/>
+                    <animations/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits"/>
                 </textField>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Time" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I86-Np-0qJ">
                     <rect key="frame" x="8" y="62" width="37" height="21"/>
+                    <animations/>
                     <constraints>
                         <constraint firstAttribute="width" constant="37" id="eAS-1k-bP6"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                     <variation key="default">
                         <mask key="constraints">
@@ -56,17 +61,41 @@
                         </mask>
                     </variation>
                 </label>
+                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1DK-GJ-0PR">
+                    <rect key="frame" x="223" y="112" width="51" height="31"/>
+                    <animations/>
+                </switch>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Light Theme" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mZk-hp-a8U">
+                    <rect key="frame" x="98" y="117" width="117" height="21"/>
+                    <animations/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="37" id="exm-bK-dm7"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="exm-bK-dm7"/>
+                        </mask>
+                    </variation>
+                </label>
             </subviews>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="nZW-fM-tCV" firstAttribute="leading" secondItem="I86-Np-0qJ" secondAttribute="trailing" constant="25" id="5Bz-Dq-Kzd"/>
                 <constraint firstItem="2jQ-R7-rgr" firstAttribute="leading" secondItem="nZW-fM-tCV" secondAttribute="trailing" constant="40" id="7up-m0-PMn"/>
+                <constraint firstItem="1DK-GJ-0PR" firstAttribute="leading" secondItem="mZk-hp-a8U" secondAttribute="trailing" constant="8" id="A4g-8e-X8L"/>
+                <constraint firstItem="1DK-GJ-0PR" firstAttribute="top" secondItem="nZW-fM-tCV" secondAttribute="bottom" constant="24" id="AYe-6j-oLT"/>
                 <constraint firstItem="7Kq-G0-zpH" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="20" id="DO1-Cg-7BM"/>
                 <constraint firstItem="nZW-fM-tCV" firstAttribute="centerY" secondItem="2jQ-R7-rgr" secondAttribute="centerY" id="Qvb-nE-p5D"/>
                 <constraint firstItem="nZW-fM-tCV" firstAttribute="top" secondItem="7Kq-G0-zpH" secondAttribute="bottom" constant="17" id="aWZ-tV-yUD"/>
                 <constraint firstAttribute="trailing" secondItem="2jQ-R7-rgr" secondAttribute="trailing" constant="20" id="bKB-Wk-GCt"/>
                 <constraint firstItem="I86-Np-0qJ" firstAttribute="centerY" secondItem="nZW-fM-tCV" secondAttribute="centerY" constant="-0.5" id="cad-hj-f03"/>
                 <constraint firstAttribute="centerX" secondItem="7Kq-G0-zpH" secondAttribute="centerX" id="eKe-fR-v9a"/>
+                <constraint firstItem="mZk-hp-a8U" firstAttribute="centerY" secondItem="1DK-GJ-0PR" secondAttribute="centerY" id="iwf-Jb-hUa"/>
+                <constraint firstItem="1DK-GJ-0PR" firstAttribute="trailing" secondItem="nZW-fM-tCV" secondAttribute="trailing" id="ix7-EF-EQ2"/>
                 <constraint firstItem="I86-Np-0qJ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="kTm-Oc-2CP"/>
             </constraints>
             <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>


### PR DESCRIPTION
I needed the light theme for the time picker - so I finished implementing it. All of the methods that set colour are now in `updateColors`, which also makes it easier to add custom colours.

The time picker was never being dealloc'ed - only hidden. I'm not sure why, but I also fixed that issue so it cleans up after being picked. (If the user wants to keep it in memory, then they just need to create a strong reference to it. But the view should dealloc cleanly by default.)

Let me know if you have any questions.

![time-picker-light](https://cloud.githubusercontent.com/assets/465971/11409449/08d97dec-938e-11e5-8777-e8b1f3eff58c.png)
