### PR TITLE
prevent selection of dates before minimum date

### DIFF
--- a/iOSUILib/iOSUILib/Calendar/MDCalendar.h
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendar.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(copy, nonatomic) NSDate *currentDate;
 @property(copy, nonatomic) NSDate *selectedDate;
+@property(copy, nonatomic) NSDate *minimumDate;
 @property(copy, nonatomic) NSDate *currentMonth;
 
 @property(assign, nonatomic) MDCalendarTheme theme;

--- a/iOSUILib/iOSUILib/Calendar/MDCalendar.m
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendar.m
@@ -47,7 +47,6 @@
 @property(weak, nonatomic) UICollectionView *collectionView;
 @property(weak, nonatomic) UICollectionViewFlowLayout *collectionViewFlowLayout;
 
-@property(copy, nonatomic) NSDate *minimumDate;
 @property(copy, nonatomic) NSDate *maximumDate;
 
 @property(nonatomic) MDCalendarCellStyle cellStyle;
@@ -143,12 +142,12 @@
  
   _cellStyle = MDCalendarCellStyleCircle;
 
-  _minimumDate = [NSDateHelper mdDateWithYear:1970 month:1 day:1];
+  self.minimumDate = [NSDateHelper mdDateWithYear:1970 month:1 day:1];
   _maximumDate = [NSDateHelper mdDateWithYear:2037 month:12 day:31];
 
   MDCalendarYearSelector *yearSelector =
       [[MDCalendarYearSelector alloc] initWithFrame:self.collectionView.frame
-                                    withMiniminDate:_minimumDate
+                                    withMiniminDate:self.minimumDate
                                      andMaximumDate:_maximumDate];
   _yearSelector = yearSelector;
   _yearSelector.delegate = self;
@@ -283,7 +282,7 @@
 
 - (NSInteger)numberOfSectionsInCollectionView:
     (UICollectionView *)collectionView {
-  return [_maximumDate mdMonthsFrom:_minimumDate] + 1;
+  return [_maximumDate mdMonthsFrom:self.minimumDate] + 1;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView
@@ -312,7 +311,7 @@
     // titleLabel.mdWidth = self.mdWidth;
     _dateHeader.dateFormatter.dateFormat = @"MMMM yyyy";
     titleLabel.text = [_dateHeader.dateFormatter
-        stringFromDate:[_minimumDate mdDateByAddingMonths:indexPath.section]];
+        stringFromDate:[self.minimumDate mdDateByAddingMonths:indexPath.section]];
 
     return cell;
   } else if (indexPath.item >= 7 && indexPath.item <= 13) {
@@ -343,7 +342,7 @@
     cell.titleColors = self.titleColors;
     cell.backgroundColors = self.backgroundColors;
     cell.cellStyle = self.cellStyle;
-    cell.month = [_minimumDate mdDateByAddingMonths:indexPath.section];
+    cell.month = [self.minimumDate mdDateByAddingMonths:indexPath.section];
     cell.currentDate = self.currentDate;
     cell.titleLabel.font = _titleFont;
     cell.date = [self dateForIndexPath:indexPath];
@@ -378,10 +377,17 @@
                        animated:NO
                  scrollPosition:UICollectionViewScrollPositionNone];
     }
+    NSDate *date = [self dateForIndexPath:indexPath];
     [cell showAnimation];
-    _selectedDate = [self dateForIndexPath:indexPath];
+    _selectedDate = date;
     [self didSelectDate:_selectedDate];
   }
+}
+
+- (BOOL) collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(nonnull NSIndexPath *)indexPath;
+{
+    NSDate *date = [self dateForIndexPath:indexPath];
+    return [self shouldSelectDate:date];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
@@ -402,7 +408,7 @@
                              scrollView.contentOffset.y / scrollView.mdHeight);
 
   NSDate *currentMonth =
-      [_minimumDate mdDateByAddingMonths:round(scrollOffset)];
+      [self.minimumDate mdDateByAddingMonths:round(scrollOffset)];
   if (![_currentMonth mdIsEqualToDateForMonth:currentMonth]) {
     _currentMonth = [currentMonth copy];
     //[self currentMonthDidChange];
@@ -417,6 +423,13 @@
     [[NSCalendarHelper mdSharedCalendar] setFirstWeekday:firstWeekday];
     [self reloadData];
   }
+}
+
+- (void) setMinimumDate:(NSDate *)minimumDate;
+{
+    _minimumDate = minimumDate;
+    self.yearSelector.minimumDate = minimumDate;
+    [self.collectionView reloadData];
 }
 
 - (void)setSelectedDate:(NSDate *)selectedDate {
@@ -476,14 +489,14 @@
 #pragma mark - Private
 
 - (void)scrollToDate:(NSDate *)date {
-  NSInteger scrollOffset = [date mdMonthsFrom:_minimumDate];
+  NSInteger scrollOffset = [date mdMonthsFrom:self.minimumDate];
   _collectionView.bounds =
       CGRectMake(0, scrollOffset * _collectionView.mdHeight,
                  _collectionView.mdWidth, _collectionView.mdHeight);
 }
 
 - (NSDate *)dateForIndexPath:(NSIndexPath *)indexPath {
-  NSDate *currentMonth = [_minimumDate mdDateByAddingMonths:indexPath.section];
+  NSDate *currentMonth = [self.minimumDate mdDateByAddingMonths:indexPath.section];
   NSDate *firstDayOfMonth = [NSDateHelper mdDateWithYear:currentMonth.mdYear
                                                    month:currentMonth.mdMonth
                                                      day:1];
@@ -499,7 +512,7 @@
 }
 
 - (NSIndexPath *)indexPathForDate:(NSDate *)date {
-  NSInteger section = [date mdMonthsFrom:_minimumDate];
+  NSInteger section = [date mdMonthsFrom:self.minimumDate];
   NSDate *firstDayOfMonth =
       [NSDateHelper mdDateWithYear:date.mdYear month:date.mdMonth day:1];
   NSInteger numberOfPlaceholdersForPrev =
@@ -513,20 +526,16 @@
 }
 
 - (BOOL)shouldSelectDate:(NSDate *)date {
-  return YES;
+  BOOL result = (date.timeIntervalSince1970 >= self.minimumDate.timeIntervalSince1970);
+  return result;
 }
 
 - (void)didSelectDate:(NSDate *)date {
-  if (_dateHeader) {
-    [_dateHeader setDate:date];
-  }
+  if ([self shouldSelectDate:date]) {
+    if (_dateHeader) {
+      [_dateHeader setDate:date];
+    }
 
-  [self didSelected];
-}
-
-- (void)didSelected {
-  if (_delegate &&
-      [_delegate respondsToSelector:@selector(calendar:didSelectDate:)]) {
     [_delegate calendar:self didSelectDate:_selectedDate];
   }
 }

--- a/iOSUILib/iOSUILib/Calendar/MDCalendar.m
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendar.m
@@ -427,8 +427,9 @@
 
 - (void) setMinimumDate:(NSDate *)minimumDate;
 {
-    _minimumDate = minimumDate;
-    self.yearSelector.minimumDate = minimumDate;
+    NSDate *date = [[NSCalendarHelper mdSharedCalendar] startOfDayForDate:minimumDate];
+    _minimumDate = date;
+    self.yearSelector.minimumDate = date;
     [self.collectionView reloadData];
 }
 

--- a/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelector.h
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelector.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSDictionary <NSNumber*, UIColor*>* titleColors UI_APPEARANCE_SELECTOR;
 @property(nonatomic) NSDictionary <NSNumber*, UIColor*>* backgroundColors UI_APPEARANCE_SELECTOR;
 
+@property(copy, nonatomic) NSDate* minimumDate;
+
 @property(nonatomic) NSInteger currentYear;
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelector.m
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelector.m
@@ -29,7 +29,6 @@
 @interface MDCalendarYearSelector () <UITableViewDelegate,
 UITableViewDataSource>
 @property(nonatomic) NSMutableArray* dataArray;
-@property(copy, nonatomic) NSDate* minimumDate;
 @property(copy, nonatomic) NSDate* maximumDate;
 @end
 
@@ -44,11 +43,7 @@ UITableViewDataSource>
         _minimumDate = minDate;
         _maximumDate = maxDate;
         
-        self.dataArray = [NSMutableArray new];
-        for (int year = (int)[minDate mdYear]; year < (int)[maxDate mdYear];
-             year++) {
-            [self.dataArray addObject:[NSString stringWithFormat:@"%i", year]];
-        }
+        [self setupDataArray];
         
         self.tableView =
         [[UITableView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)
@@ -68,6 +63,14 @@ UITableViewDataSource>
     
     [self relayout];
     return self;
+}
+
+- (void) setupDataArray;
+{
+  self.dataArray = [NSMutableArray new];
+  for (int year = (int)[self.minimumDate mdYear]; year < (int)[self.maximumDate mdYear]; year++) {
+    [self.dataArray addObject:[NSString stringWithFormat:@"%i", year]];
+  }
 }
 
 - (void)layoutSubviews {
@@ -140,6 +143,13 @@ UITableViewDataSource>
                         inSection:newIndexPath.section]
      atScrollPosition:UITableViewScrollPositionMiddle
      animated:NO];
+}
+
+- (void) setMinimumDate:(NSDate *)minimumDate;
+{
+    _minimumDate = minimumDate;
+    [self setupDataArray];
+    [self.tableView reloadData];
 }
 
 #pragma mark - UITableViewDelegate

--- a/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.h
+++ b/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.h
@@ -34,6 +34,7 @@
 @interface MDDatePickerDialog : UIButton
 
 @property (nullable, strong, nonatomic) NSDate *selectedDate;
+@property (nonnull, strong, nonatomic) NSDate *minimumDate;
 @property(weak, nonatomic) id<MDDatePickerDialogDelegate> delegate;
 
 - (void)show;

--- a/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.m
+++ b/iOSUILib/iOSUILib/Calendar/MDDatePickerDialog.m
@@ -260,6 +260,14 @@
   self.hidden = YES;
 }
 
+- (NSDate*)minimumDate {
+    return self.calendar.minimumDate;
+}
+
+- (void)setMinimumDate:(NSDate *)minimumDate {
+  self.calendar.minimumDate = minimumDate;
+}
+
 - (void)deviceOrientationDidChange:(NSNotification *)notification {
   UIInterfaceOrientation orientation =
       [[UIApplication sharedApplication] statusBarOrientation];

--- a/iOSUILibDemo/DatePickerDialogController.m
+++ b/iOSUILibDemo/DatePickerDialogController.m
@@ -50,11 +50,12 @@
     NSDateComponents *dateComponents = [[NSDateComponents alloc] init];
     dateComponents.year = 1980;
     dateComponents.month = 1;
-    dateComponents.day = 1;
+    dateComponents.day = 5;
     NSDate *date = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
       
     MDDatePickerDialog *datePicker = [[MDDatePickerDialog alloc] init];
     _datePicker = datePicker;
+    _datePicker.minimumDate = date;
     _datePicker.selectedDate = date;
     _datePicker.delegate = self;
   }


### PR DESCRIPTION

I needed to prevent the selection of dates before the current date. To do this, I exposed the `minimumDate` property in `MDCalendar`. Any selections before the minimum date are prevented using the UICollectionViewDelegate `shouldSelect...` method.

Let me know if you have any questions!