### PR TITLE
Disable implicit animation in calendar year deselect

### DIFF
--- a/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelectorViewCell.m
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelectorViewCell.m
@@ -72,7 +72,9 @@
     _backgroundCurentYearLayer.hidden = NO;
     [self.textLabel setTextColor:_titleColors[@(MDCalendarCellStateSelected)]];
   } else {
+    [CATransaction setDisableActions:YES];
     _backgroundCurentYearLayer.hidden = YES;
+    [CATransaction setDisableActions:NO];
     [self.textLabel setTextColor:_titleColors[@(MDCalendarCellStateNormal)]];
   }
 }

--- a/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelectorViewCell.m
+++ b/iOSUILib/iOSUILib/Calendar/MDCalendarYearSelectorViewCell.m
@@ -72,9 +72,10 @@
     _backgroundCurentYearLayer.hidden = NO;
     [self.textLabel setTextColor:_titleColors[@(MDCalendarCellStateSelected)]];
   } else {
+    [CATransaction begin];
     [CATransaction setDisableActions:YES];
     _backgroundCurentYearLayer.hidden = YES;
-    [CATransaction setDisableActions:NO];
+    [CATransaction commit];
     [self.textLabel setTextColor:_titleColors[@(MDCalendarCellStateNormal)]];
   }
 }


### PR DESCRIPTION
In the `MDCalendar`, if you select a year, and then scroll quickly, another cell will briefly show the implicit animation when the `backgroundCurentYearLayer` is hidden. (You can also see this animation, if you select the year from the calendar, select the previous year, then select the year from the calendar again.)

This PR removes the implicit animation on deselection.