### PR TITLE
add tab bar normal text color property

### DIFF
--- a/iOSUILib/iOSUILib/MDTabBar.h
+++ b/iOSUILib/iOSUILib/MDTabBar.h
@@ -31,12 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MDTabBarDelegate <NSObject>
 - (void)tabBar:(MDTabBar *)tabBar
     didChangeSelectedIndex:(NSUInteger)selectedIndex;
-
 @end
-IB_DESIGNABLE
-@interface MDTabBar : UIControl
 
+IB_DESIGNABLE
+@interface MDTabBar : UIView
+
+/// selected text color
 @property(null_unspecified, nonatomic) IBInspectable UIColor *textColor;
+/// normal (not selected) text color
+@property(null_unspecified, nonatomic) IBInspectable UIColor *normalTextColor;
 @property(null_unspecified, nonatomic) IBInspectable UIColor *backgroundColor;
 @property(null_unspecified, nonatomic) IBInspectable UIColor *indicatorColor;
 @property(null_unspecified, nonatomic) IBInspectable UIColor *rippleColor;

--- a/iOSUILib/iOSUILib/MDTabBar.h
+++ b/iOSUILib/iOSUILib/MDTabBar.h
@@ -44,7 +44,11 @@ IB_DESIGNABLE
 @property(null_unspecified, nonatomic) IBInspectable UIColor *indicatorColor;
 @property(null_unspecified, nonatomic) IBInspectable UIColor *rippleColor;
 
+/// selected font
 @property(nullable, nonatomic) UIFont *textFont;
+/// normal (not selected) font
+@property(nullable, nonatomic) UIFont *normalTextFont;
+
 @property(nonatomic) NSUInteger selectedIndex;
 @property(nonatomic, weak) id<MDTabBarDelegate> delegate;
 @property(nonatomic, readonly) NSInteger numberOfItems;

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -32,22 +32,25 @@
 #define kMDContentHorizontalPaddingIPhone 12
 #define kMDTabBarHorizontalInset 8
 
-#define DISABLED_TEXT_ALPHA .6
+#pragma mark - MDTabBar
 
 @interface MDTabBar ()
-
 - (void)updateSelectedIndex:(NSInteger)selectedIndex;
 @end
+
+#pragma mark - MDSegmentedControl
 
 @interface MDSegmentedControl : UISegmentedControl
 
 @property(nonatomic) UIColor *rippleColor;
 @property(nonatomic) UIColor *indicatorColor;
 @property(nonatomic) NSMutableArray <UIView*>*tabs;
+
 - (CGRect)getSelectedSegmentFrame;
 - (void)setTextFont:(UIFont *)textFont withColor:(UIColor *)textColor;
 
 @end
+
 
 @implementation MDSegmentedControl {
   UIView *indicatorView;
@@ -185,15 +188,20 @@
 
 - (void)setTextFont:(UIFont *)textFont withColor:(UIColor *)textColor {
   font = textFont;
-  [self setTitleTextAttributes:@{
-    NSForegroundColorAttributeName :
-        [textColor colorWithAlphaComponent:DISABLED_TEXT_ALPHA],
-    NSFontAttributeName : textFont
-  } forState:UIControlStateNormal];
-  [self setTitleTextAttributes:@{
-    NSForegroundColorAttributeName : textColor,
-    NSFontAttributeName : textFont
-  } forState:UIControlStateSelected];
+  CGFloat disabledTextAlpha = 0.6;
+  UIColor *normalTextColor = tabBar.normalTextColor;
+  if (normalTextColor == nil) {
+    normalTextColor = [textColor colorWithAlphaComponent:disabledTextAlpha];
+  }
+  
+  NSDictionary *attributes = @{ NSForegroundColorAttributeName : normalTextColor,
+                                NSFontAttributeName : textFont
+                                };
+  [self setTitleTextAttributes:attributes forState:UIControlStateNormal];
+  NSDictionary *selectedAttributes = @{ NSForegroundColorAttributeName : textColor,
+                                        NSFontAttributeName : textFont
+                                        };
+  [self setTitleTextAttributes:selectedAttributes forState:UIControlStateSelected];
 }
 
 - (void)moveIndicatorToFrame:(CGRect)frame withAnimated:(BOOL)animated {
@@ -384,7 +392,8 @@
 
 @end
 
-#pragma mark MDTabBar
+#pragma mark - MDTabBar
+
 @implementation MDTabBar {
   MDSegmentedControl *segmentedControl;
   UIScrollView *scrollView;
@@ -560,6 +569,12 @@
 - (void)setTextColor:(UIColor *)textColor {
   _textColor = textColor;
   [self updateItemAppearance];
+}
+
+- (void)setNormalTextColor:(UIColor *)normalTextColor;
+{
+    _normalTextColor = normalTextColor;
+    [self updateItemAppearance];
 }
 
 - (void)setIndicatorColor:(UIColor *)indicatorColor {

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -193,9 +193,13 @@
   if (normalTextColor == nil) {
     normalTextColor = [textColor colorWithAlphaComponent:disabledTextAlpha];
   }
-  
+    
+  UIFont *normalTextFont = tabBar.normalTextFont;
+  if (normalTextFont == nil) {
+    normalTextFont = textFont;
+  }
   NSDictionary *attributes = @{ NSForegroundColorAttributeName : normalTextColor,
-                                NSFontAttributeName : textFont
+                                NSFontAttributeName : normalTextFont
                                 };
   [self setTitleTextAttributes:attributes forState:UIControlStateNormal];
   NSDictionary *selectedAttributes = @{ NSForegroundColorAttributeName : textColor,
@@ -590,6 +594,11 @@
 - (void)setTextFont:(UIFont *)textFont {
   _textFont = textFont;
   [self updateItemAppearance];
+}
+
+- (void)setNormalTextFont:(UIFont *)normalTextFont {
+    _normalTextFont = normalTextFont;
+    [self updateItemAppearance];
 }
 
 - (void)setSelectedIndex:(NSUInteger)selectedIndex {


### PR DESCRIPTION
I needed to set a color for the normal tab bar (i.e. not selected) text. I added a `normalTextColor` to `MDTabBar` which is used by the `MDSegmentedControl`.

Let me know if you have any questions. Thanks!