### PR TITLE
add horizontal inset property

### DIFF
--- a/iOSUILib/iOSUILib/MDTabBar.h
+++ b/iOSUILib/iOSUILib/MDTabBar.h
@@ -42,6 +42,12 @@ IB_DESIGNABLE
 @property(null_unspecified, nonatomic) IBInspectable UIColor *rippleColor;
 
 @property(nullable, nonatomic) UIFont *textFont;
+/// normal (not selected) font
+@property(nullable, nonatomic) UIFont *normalTextFont;
+
+/// inset from the side (default: 8)
+@property(nonatomic, assign) CGFloat horizontalInset;
+
 @property(nonatomic) NSUInteger selectedIndex;
 @property(nonatomic, weak) id<MDTabBarDelegate> delegate;
 @property(nonatomic, readonly) NSInteger numberOfItems;

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -30,7 +30,6 @@
 
 #define kMDContentHorizontalPaddingIPad 24
 #define kMDContentHorizontalPaddingIPhone 12
-#define kMDTabBarHorizontalInset 8
 
 #define DISABLED_TEXT_ALPHA .6
 
@@ -245,7 +244,7 @@
   }
 
   CGFloat holderWidth =
-      self.superview.bounds.size.width - kMDTabBarHorizontalInset * 2;
+      self.superview.bounds.size.width - tabBar.horizontalInset * 2;
   if (segmentedControlWidth < holderWidth) {
     if (self.numberOfSegments * maxItemSize < holderWidth) {
       maxItemSize = holderWidth / self.numberOfSegments;
@@ -424,8 +423,8 @@
 - (void)layoutSubviews {
   [super layoutSubviews];
   scrollView.frame = CGRectMake(0, 0, self.bounds.size.width, kMDTabBarHeight);
-  [scrollView setContentInset:UIEdgeInsetsMake(0, kMDTabBarHorizontalInset, 0,
-                                               kMDTabBarHorizontalInset)];
+  [scrollView setContentInset:UIEdgeInsetsMake(0, self.horizontalInset, 0,
+                                               self.horizontalInset)];
   [scrollView setContentSize:segmentedControl.bounds.size];
 }
 
@@ -487,14 +486,15 @@
 
 - (void)scrollToSelectedIndex {
   CGRect frame = [segmentedControl getSelectedSegmentFrame];
-  CGFloat contentOffset = frame.origin.x + kMDTabBarHorizontalInset -
+  CGFloat horizontalInset = self.horizontalInset;
+  CGFloat contentOffset = frame.origin.x + horizontalInset -
                           (self.frame.size.width - frame.size.width) / 2;
-  if (contentOffset > scrollView.contentSize.width + kMDTabBarHorizontalInset -
+  if (contentOffset > scrollView.contentSize.width + horizontalInset -
                           self.frame.size.width) {
-    contentOffset = scrollView.contentSize.width + kMDTabBarHorizontalInset -
+    contentOffset = scrollView.contentSize.width + horizontalInset -
                     self.frame.size.width;
-  } else if (contentOffset < -kMDTabBarHorizontalInset) {
-    contentOffset = -kMDTabBarHorizontalInset;
+  } else if (contentOffset < -horizontalInset) {
+    contentOffset = -horizontalInset;
   }
 
   [scrollView setContentOffset:CGPointMake(contentOffset, 0) animated:YES];
@@ -585,6 +585,12 @@
       [self scrollToSelectedIndex];
     }
   }
+}
+
+- (void) setHorizontalInset:(CGFloat)horizontalInset;
+{
+  _horizontalInset = horizontalInset;
+  [self setNeedsLayout];
 }
 
 - (NSInteger)numberOfItems {

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -430,6 +430,8 @@
 
 #pragma mark Private methods
 - (void)initContent {
+  self.horizontalInset = 8;
+
   segmentedControl = [[MDSegmentedControl alloc] initWithTabBar:self];
   [segmentedControl setTintColor:[UIColor clearColor]];
 


### PR DESCRIPTION
According to the [Google Material Design specs](https://www.google.com/design/spec/components/tabs.html#tabs-usage), the indicator on tabs goes to the edge. Currently the tab had a default horizontal inset of 8. I've left the default unchanged, but now it can be changed to 0 to match the spec.

<img width="375" alt="default-horizontal-inset" src="https://cloud.githubusercontent.com/assets/465971/11511978/f79b851a-9839-11e5-9c72-b0f2dff8f026.png">

`horizontalInset = 0`:

<img width="375" alt="wall-to-wall" src="https://cloud.githubusercontent.com/assets/465971/11511803/0b544b2e-9839-11e5-9879-ba14506784d0.png">
