### PR TITLE
Prevent unimplemented delegate calls

### DIFF
--- a/iOSUILib/iOSUILib.xcodeproj/project.pbxproj
+++ b/iOSUILib/iOSUILib.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		88F22A4E1B37BA71004B6435 /* MDBubbleLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F22A4D1B37BA71004B6435 /* MDBubbleLabel.m */; };
 		88F578C71A80B5E6008A14BB /* MDTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F578C61A80B5E6008A14BB /* MDTableViewCell.m */; };
 		9251905C1AC90B8300D4FC0A /* UIView+MDExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 9251905B1AC90B8300D4FC0A /* UIView+MDExtension.m */; };
+		FAE4CD191C2B5310004083D6 /* MDButtonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAE4CD181C2B5310004083D6 /* MDButtonTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,6 +218,7 @@
 		88F578C61A80B5E6008A14BB /* MDTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDTableViewCell.m; sourceTree = "<group>"; };
 		9251905A1AC90B8300D4FC0A /* UIView+MDExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+MDExtension.h"; sourceTree = "<group>"; };
 		9251905B1AC90B8300D4FC0A /* UIView+MDExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+MDExtension.m"; sourceTree = "<group>"; };
+		FAE4CD181C2B5310004083D6 /* MDButtonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDButtonTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -357,6 +359,7 @@
 			isa = PBXGroup;
 			children = (
 				882891371A7F218B00944560 /* Supporting Files */,
+				FAE4CD181C2B5310004083D6 /* MDButtonTests.m */,
 			);
 			path = iOSUILibTests;
 			sourceTree = "<group>";
@@ -564,6 +567,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAE4CD191C2B5310004083D6 /* MDButtonTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSUILib/iOSUILib/MDButton.m
+++ b/iOSUILib/iOSUILib/MDButton.m
@@ -184,11 +184,11 @@
                                  self.btImage.transform = CGAffineTransformMakeRotation(M_PI/4);
                              } completion:^(BOOL finished) {
                                  _rotated = true;
-                                 if (_mdButtonDelegate) {
+                                 if ([_mdButtonDelegate respondsToSelector:@selector(rotationCompleted:)]) {
                                      [_mdButtonDelegate rotationCompleted:self];
                                  }
                              }];
-            if (_mdButtonDelegate) {
+            if ([_mdButtonDelegate respondsToSelector:@selector(rotationStarted:)]) {
                 [_mdButtonDelegate rotationStarted:self];
             }
         } else {
@@ -199,11 +199,11 @@
                                  self.btImage.transform = CGAffineTransformMakeRotation(0);
                              } completion:^(BOOL finished) {
                                  _rotated = false;
-                                 if (_mdButtonDelegate) {
+                                 if ([_mdButtonDelegate respondsToSelector:@selector(rotationCompleted:)]) {
                                      [_mdButtonDelegate rotationCompleted:self];
                                  }
                              }];
-            if (_mdButtonDelegate) {
+            if ([_mdButtonDelegate respondsToSelector:@selector(rotationStarted:)]) {
                 [_mdButtonDelegate rotationStarted:self];
             }
         }
@@ -234,12 +234,12 @@
                                      self.btImage.transform = CGAffineTransformMakeRotation(0);
                                  }completion:^(BOOL finished) {
                                      _rotated = true;
-                                     if (_mdButtonDelegate) {
+                                     if ([_mdButtonDelegate respondsToSelector:@selector(rotationCompleted:)]) {
                                          [_mdButtonDelegate rotationCompleted:self];
                                      }
                                  }];
                              }];
-            if (_mdButtonDelegate) {
+            if ([_mdButtonDelegate respondsToSelector:@selector(rotationStarted:)]) {
                 [_mdButtonDelegate rotationStarted:self];
             }
         } else {
@@ -269,12 +269,12 @@
                                      self.btImage.transform = CGAffineTransformMakeRotation(0);
                                  }completion:^(BOOL finished) {
                                      _rotated = false;
-                                     if (_mdButtonDelegate) {
+                                     if ([_mdButtonDelegate respondsToSelector:@selector(rotationCompleted:)]) {
                                          [_mdButtonDelegate rotationCompleted:self];
                                      }
                                  }];
                              }];
-            if (_mdButtonDelegate) {
+            if ([_mdButtonDelegate respondsToSelector:@selector(rotationStarted:)]) {
                 [_mdButtonDelegate rotationStarted:self];
             }
         }

--- a/iOSUILib/iOSUILibTests/MDButtonTests.m
+++ b/iOSUILib/iOSUILibTests/MDButtonTests.m
@@ -1,0 +1,55 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 FPT Software
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "MDButton.h"
+
+// A dummy MDButtonDelegate that doesn't implement any of its @optional methods
+@interface DummyMDButtonDelegate : NSObject <MDButtonDelegate>
+
+@end
+
+@implementation DummyMDButtonDelegate
+
+
+@end
+
+@interface MDButtonTests : XCTestCase
+
+@end
+
+@implementation MDButtonTests
+
+- (void)testOptionalDelegateMethodsShouldNotCrashIfNotImplemented {
+    MDButton *button = [[MDButton alloc] init];
+    DummyMDButtonDelegate *delegate = [DummyMDButtonDelegate new];
+    button.mdButtonDelegate = delegate;
+
+    // Animate this block so that the animation blocks that call rotationCompleted are run.
+    [UIView animateWithDuration:1.5 animations:^{
+        button.rotated = YES;
+    } completion:nil];
+
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]];
+}
+
+@end


### PR DESCRIPTION
My app was crashing with `unrecognizedSelector` when I didn't implement the optional delegate methods on `MDButtonDelegate`, so I added checks to make the methods truly optional.