### PR TITLE
add imageSize property for MDButtons

### DIFF
--- a/iOSUILib/iOSUILib/MDButton.h
+++ b/iOSUILib/iOSUILib/MDButton.h
@@ -47,6 +47,7 @@ IB_DESIGNABLE
 @property(nonatomic, getter=isEnabled) IBInspectable BOOL enabled;
 @property(nonatomic) IBInspectable UIImage * imageNormal;
 @property(nonatomic) IBInspectable UIImage * imageRotated;
+@property(nonatomic) IBInspectable CGFloat imageSize;
 
 @property(nonatomic) MDButtonType mdButtonType;
 @property(nonatomic, getter=isRotated) BOOL rotated;;

--- a/iOSUILib/iOSUILib/MDButton.m
+++ b/iOSUILib/iOSUILib/MDButton.m
@@ -158,12 +158,31 @@
     
     if (_btImage == nil) {
         _btImage = [[UIImageView alloc] initWithImage:_imageNormal];
-        _btImage.frame = self.bounds;
-        _btImage.contentMode = UIViewContentModeCenter;
+
+        if (_imageSize) {
+            [self adjustImageSize];
+        } else {
+            _btImage.contentMode = UIViewContentModeCenter;
+            _btImage.frame = self.bounds;
+        }
+
         _btImage.clipsToBounds = NO;
         
         [self addSubview:_btImage];
     }
+}
+
+-(void)setImageSize:(CGFloat)imageSize {
+    _imageSize = imageSize;
+    [self adjustImageSize];
+}
+
+- (void)adjustImageSize {
+    CGFloat centerX = self.bounds.size.width / 2;
+    CGFloat centerY = self.bounds.size.height / 2;
+    CGRect buttonBounds = CGRectMake(centerX - _imageSize / 2, centerY - _imageSize / 2, _imageSize, _imageSize);
+    _btImage.contentMode = UIViewContentModeScaleAspectFit;
+    _btImage.frame = buttonBounds;
 }
 
 -(void)setRotated:(BOOL)rotated{

--- a/iOSUILibDemo/ButtonViewController.xib
+++ b/iOSUILibDemo/ButtonViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="Roboto-Regular.ttf">
@@ -32,7 +32,6 @@
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gAF-jj-cFt" customClass="MDButton">
                     <rect key="frame" x="8" y="78" width="150" height="40"/>
-                    <animations/>
                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="16"/>
                     <state key="normal" title="Flat Button">
                         <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -48,7 +47,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T5G-pq-LxU" customClass="MDButton">
                     <rect key="frame" x="162" y="78" width="150" height="40"/>
-                    <animations/>
                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="16"/>
                     <state key="normal" title="Flat Button">
                         <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -65,7 +63,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FcZ-7R-x1H" customClass="MDButton">
                     <rect key="frame" x="8" y="30" width="150" height="40"/>
-                    <animations/>
                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="16"/>
                     <state key="normal" title="Raised Button">
                         <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -77,7 +74,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c2q-1M-n3Q" customClass="MDButton">
                     <rect key="frame" x="162" y="30" width="150" height="40"/>
-                    <animations/>
                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="16"/>
                     <state key="normal" title="Raised Button">
                         <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -95,7 +91,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bbi-av-hRe" customClass="MDButton">
                     <rect key="frame" x="33" y="126" width="100" height="100"/>
-                    <animations/>
                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="36"/>
                     <state key="normal" title="+">
@@ -110,7 +105,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Rw-3K-vaO" customClass="MDButton">
                     <rect key="frame" x="187" y="126" width="100" height="100"/>
-                    <animations/>
                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="36"/>
                     <state key="normal" title="+">
@@ -125,15 +119,13 @@
                     </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Avi-UM-epm" customClass="MDButton">
-                    <rect key="frame" x="123" y="413" width="75" height="30"/>
-                    <animations/>
+                    <rect key="frame" x="123" y="521" width="75" height="30"/>
                     <state key="normal" title="Button">
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                     </state>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IZa-SH-yB2" customClass="MDButton">
                     <rect key="frame" x="187" y="269" width="100" height="100"/>
-                    <animations/>
                     <color key="backgroundColor" red="1" green="0.0" blue="0.084490335540000003" alpha="1" colorSpace="calibratedRGB"/>
                     <color key="tintColor" red="0.9349183137" green="1" blue="0.98822774759999998" alpha="1" colorSpace="calibratedRGB"/>
                     <state key="normal">
@@ -148,7 +140,6 @@
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tL0-Fw-JIb" customClass="MDButton">
                     <rect key="frame" x="33" y="269" width="100" height="100"/>
-                    <animations/>
                     <color key="backgroundColor" red="1" green="0.0" blue="0.123524881" alpha="1" colorSpace="calibratedRGB"/>
                     <state key="normal">
                         <color key="titleColor" red="0.9349183137" green="1" blue="0.98822774759999998" alpha="1" colorSpace="calibratedRGB"/>
@@ -161,8 +152,24 @@
                         <userDefinedRuntimeAttribute type="image" keyPath="imageRotated" value="bt-icon2.png"/>
                     </userDefinedRuntimeAttributes>
                 </button>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VS2-86-lNA" customClass="MDButton">
+                    <rect key="frame" x="187" y="400" width="100" height="100"/>
+                    <color key="backgroundColor" red="1" green="0.0" blue="0.084490335540000003" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="tintColor" red="0.9349183137" green="1" blue="0.98822774759999998" alpha="1" colorSpace="calibratedRGB"/>
+                    <state key="normal">
+                        <color key="titleColor" red="0.8980392157" green="0.8980392157" blue="0.8980392157" alpha="1" colorSpace="calibratedRGB"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="type">
+                            <integer key="value" value="3"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="image" keyPath="imageNormal" value="bt-icon-plus.png"/>
+                        <userDefinedRuntimeAttribute type="number" keyPath="imageSize">
+                            <integer key="value" value="15"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </button>
             </subviews>
-            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
         </view>


### PR DESCRIPTION
I found that I wanted to re-use an existing image asset in my project for a new MDButton, but it wasn't of the right size.
I couldn't figure out how to configure the size of the button's image, so I added this new property.

If I missed some already-configurable option, please let me know!