### PR TITLE
Fixed file not found build errors in demo project

### DIFF
--- a/iOSUILibDemo/SnackBarViewController.m
+++ b/iOSUILibDemo/SnackBarViewController.m
@@ -22,7 +22,7 @@
 
 #import "iOSUILib/MDSnackbar.h"
 #import "SnackBarViewController.h"
-#import "iOSUILib/UIColorHelper.h"
+#import "UIColorHelper.h"
 
 @interface SnackBarViewController ()
 

--- a/iOSUILibDemo/TableViewController.m
+++ b/iOSUILibDemo/TableViewController.m
@@ -23,7 +23,7 @@
 #import "TableViewController.h"
 #import "MockData.h"
 #import "iOSUILib/MDTableViewCell.h"
-#import "iOSUILib/UIFontHelper.h"
+#import "UIFontHelper.h"
 
 @interface TableViewController () <UITableViewDataSource, UITableViewDelegate>
 


### PR DESCRIPTION
I was getting file not found errors for UIFontHelper.h and UIColorHelper.h. I think those errors have emerged after 0dc362f commit.

So, i simply changed import paths for them.