### PR TITLE
fix deprecated calendar enums

### DIFF
--- a/iOSUILib/iOSUILib/Calendar/NSDate+MDExtension.m
+++ b/iOSUILib/iOSUILib/Calendar/NSDate+MDExtension.m
@@ -113,13 +113,18 @@
 - (NSInteger)mdYearsFrom:(NSDate *)date {
   NSCalendar *calendar = [NSCalendarHelper mdSharedCalendar];
   NSDateComponents *dateComponents = [calendar
-      components:NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit
+      components:NSCalendarUnitDay | NSCalendarUnitMonth
+ | NSCalendarUnitYear
+
         fromDate:date];
   [dateComponents setDay:1];
   [dateComponents setMonth:1];
 
   NSDateComponents *myComponents = [calendar
-      components:NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit
+      components:NSCalendarUnitDay
+ | NSCalendarUnitMonth
+ | NSCalendarUnitYear
+
         fromDate:self];
   [myComponents setDay:1];
   [myComponents setMonth:1];
@@ -135,12 +140,18 @@
 - (NSInteger)mdMonthsFrom:(NSDate *)date {
   NSCalendar *calendar = [NSCalendarHelper mdSharedCalendar];
   NSDateComponents *dateComponents = [calendar
-      components:NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit
+      components:NSCalendarUnitDay
+ | NSCalendarUnitMonth
+ | NSCalendarUnitYear
+
         fromDate:date];
   [dateComponents setDay:1];
     
   NSDateComponents *myComponents = [calendar
-      components:NSDayCalendarUnit | NSMonthCalendarUnit | NSYearCalendarUnit
+      components:NSCalendarUnitDay
+ | NSCalendarUnitMonth
+ | NSCalendarUnitYear
+
         fromDate:self];
   [myComponents setDay:1];
     

--- a/iOSUILib/iOSUILib/Calendar/NSDate+MDExtension.m
+++ b/iOSUILib/iOSUILib/Calendar/NSDate+MDExtension.m
@@ -113,18 +113,13 @@
 - (NSInteger)mdYearsFrom:(NSDate *)date {
   NSCalendar *calendar = [NSCalendarHelper mdSharedCalendar];
   NSDateComponents *dateComponents = [calendar
-      components:NSCalendarUnitDay | NSCalendarUnitMonth
- | NSCalendarUnitYear
-
+      components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
         fromDate:date];
   [dateComponents setDay:1];
   [dateComponents setMonth:1];
 
   NSDateComponents *myComponents = [calendar
-      components:NSCalendarUnitDay
- | NSCalendarUnitMonth
- | NSCalendarUnitYear
-
+      components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
         fromDate:self];
   [myComponents setDay:1];
   [myComponents setMonth:1];
@@ -140,10 +135,7 @@
 - (NSInteger)mdMonthsFrom:(NSDate *)date {
   NSCalendar *calendar = [NSCalendarHelper mdSharedCalendar];
   NSDateComponents *dateComponents = [calendar
-      components:NSCalendarUnitDay
- | NSCalendarUnitMonth
- | NSCalendarUnitYear
-
+      components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
         fromDate:date];
   [dateComponents setDay:1];
     

--- a/iOSUILibDemo/Images.xcassets/LaunchImage.launchimage/Contents.json
+++ b/iOSUILibDemo/Images.xcassets/LaunchImage.launchimage/Contents.json
@@ -3,43 +3,30 @@
     {
       "orientation" : "portrait",
       "idiom" : "ipad",
-      "minimum-system-version" : "7.0",
       "extent" : "full-screen",
-      "scale" : "2x"
-    },
-    {
-      "orientation" : "landscape",
-      "idiom" : "ipad",
       "minimum-system-version" : "7.0",
-      "extent" : "full-screen",
       "scale" : "1x"
     },
     {
       "orientation" : "landscape",
       "idiom" : "ipad",
-      "minimum-system-version" : "7.0",
       "extent" : "full-screen",
-      "scale" : "2x"
-    },
-    {
-      "orientation" : "portrait",
-      "idiom" : "iphone",
       "minimum-system-version" : "7.0",
-      "scale" : "2x"
-    },
-    {
-      "orientation" : "portrait",
-      "idiom" : "iphone",
-      "minimum-system-version" : "7.0",
-      "subtype" : "retina4",
-      "scale" : "2x"
+      "scale" : "1x"
     },
     {
       "orientation" : "portrait",
       "idiom" : "ipad",
-      "minimum-system-version" : "7.0",
       "extent" : "full-screen",
-      "scale" : "1x"
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "ipad",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/iOSUILibDemo/TabBarViewControllerViewController.m
+++ b/iOSUILibDemo/TabBarViewControllerViewController.m
@@ -117,7 +117,7 @@
   TabContentViewController *controller =
       [[TabContentViewController alloc] init];
   dispatch_async(dispatch_get_main_queue(), ^{
-    [controller setContent:[NSString stringWithFormat:@"Tab %u", index + 1]];
+    [controller setContent:[NSString stringWithFormat:@"Tab %d", (int)index + 1]];
   });
   return controller;
 }


### PR DESCRIPTION
For deployment targets of iOS8 or higher, there are compiler warnings for using deprecated calendar enums.