### PR TITLE
Configurable tab bar item horizontal padding

### DIFF
--- a/iOSUILib/iOSUILib/MDTabBar.h
+++ b/iOSUILib/iOSUILib/MDTabBar.h
@@ -52,7 +52,7 @@ IB_DESIGNABLE
 /// inset from the side (default: 8)
 @property(nonatomic, assign) CGFloat horizontalInset;
 
-/// padding for each item in tab bar (default: iPhone=12, iPad=24)
+/// padding for each item in tab bar (default: iPhone=12, iPad=24) Values <4 can cause labels to be truncated
 @property(nonatomic, assign) CGFloat horizontalPaddingPerItem;
 
 @property(nonatomic) NSUInteger selectedIndex;

--- a/iOSUILib/iOSUILib/MDTabBar.h
+++ b/iOSUILib/iOSUILib/MDTabBar.h
@@ -52,6 +52,9 @@ IB_DESIGNABLE
 /// inset from the side (default: 8)
 @property(nonatomic, assign) CGFloat horizontalInset;
 
+/// padding for each item in tab bar (default: iPhone=12, iPad=24)
+@property(nonatomic, assign) CGFloat horizontalPaddingPerItem;
+
 @property(nonatomic) NSUInteger selectedIndex;
 @property(nonatomic, weak) id<MDTabBarDelegate> delegate;
 @property(nonatomic, readonly) NSInteger numberOfItems;

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -28,9 +28,6 @@
 #import <Foundation/Foundation.h>
 #import "UIFontHelper.h"
 
-//#define kMDContentHorizontalPaddingIPad 24
-//#define kMDContentHorizontalPaddingIPhone 12
-
 #pragma mark - MDTabBar
 
 @interface MDTabBar ()
@@ -232,12 +229,12 @@
   CGFloat maxItemSize = 0;
   CGFloat segmentedControlWidth = 0;
 
+  NSDictionary *attributes = @{NSFontAttributeName : font};
   for (int i = 0; i < self.numberOfSegments; i++) {
     NSString *title = [self titleForSegmentAtIndex:i];
     CGSize itemSize = CGSizeZero;
     if (title) {
-      itemSize = [title sizeWithAttributes:@{NSFontAttributeName : font}];
-
+      itemSize = [title sizeWithAttributes:attributes];
     } else {
       UIImage *image = [self imageForSegmentAtIndex:i];
       CGFloat height = self.bounds.size.height;

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -28,8 +28,8 @@
 #import <Foundation/Foundation.h>
 #import "UIFontHelper.h"
 
-#define kMDContentHorizontalPaddingIPad 24
-#define kMDContentHorizontalPaddingIPhone 12
+//#define kMDContentHorizontalPaddingIPad 24
+//#define kMDContentHorizontalPaddingIPhone 12
 
 #pragma mark - MDTabBar
 
@@ -41,6 +41,7 @@
 
 @interface MDSegmentedControl : UISegmentedControl
 
+@property(nonatomic) CGFloat horizontalPadding;
 @property(nonatomic) UIColor *rippleColor;
 @property(nonatomic) UIColor *indicatorColor;
 @property(nonatomic) NSMutableArray<UIView *> *tabs;
@@ -67,6 +68,7 @@
                   action:@selector(selectionChanged:)
         forControlEvents:UIControlEventValueChanged];
     tabBar = bar;
+      
   }
 
   return self;
@@ -243,11 +245,8 @@
       itemSize = CGSizeMake(width, height);
     }
 
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
-      itemSize.width += kMDContentHorizontalPaddingIPad * 2;
-    else
-      itemSize.width += kMDContentHorizontalPaddingIPhone * 2;
-
+    itemSize.width += self.horizontalPadding * 2;
+      
     [self setWidth:itemSize.width forSegmentAtIndex:i];
 
     segmentedControlWidth += (itemSize.width);
@@ -456,6 +455,9 @@
   [scrollView addSubview:segmentedControl];
 
   [self addSubview:scrollView];
+  
+  self.horizontalPaddingPerItem = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) ? 24 : 12;
+  segmentedControl.horizontalPadding = self.horizontalPaddingPerItem;
 
   [self setBackgroundColor:[UIColorHelper colorWithRGBA:kMDColorPrimary500]];
   self.layer.shadowColor = [UIColor blackColor].CGColor;
@@ -563,6 +565,12 @@
 
 - (void)moveIndicatorToFrame:(CGRect)frame withAnimated:(BOOL)animated {
   [segmentedControl moveIndicatorToFrame:frame withAnimated:animated];
+}
+
+- (void) setHorizontalPaddingPerItem:(CGFloat)padding;
+{
+  segmentedControl.horizontalPadding = padding;
+  //[segmentedControl resizeItems];
 }
 
 #pragma mark Setters

--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -566,8 +566,8 @@
 
 - (void) setHorizontalPaddingPerItem:(CGFloat)padding;
 {
+  _horizontalPaddingPerItem = padding;
   segmentedControl.horizontalPadding = padding;
-  //[segmentedControl resizeItems];
 }
 
 #pragma mark Setters

--- a/iOSUILibDemo/TabBarViewControllerViewController.m
+++ b/iOSUILibDemo/TabBarViewControllerViewController.m
@@ -104,7 +104,6 @@
   //  tabBarViewController.selectedIndex = 3;
   self.title = @"MDTabBarViewController";
   
-  //tabBarViewController.tabBar.horizontalPaddingPerItem = 0; // FIXME:
 }
 
 - (void)didReceiveMemoryWarning {

--- a/iOSUILibDemo/TabBarViewControllerViewController.m
+++ b/iOSUILibDemo/TabBarViewControllerViewController.m
@@ -103,6 +103,8 @@
 
   //  tabBarViewController.selectedIndex = 3;
   self.title = @"MDTabBarViewController";
+  
+  //tabBarViewController.tabBar.horizontalPaddingPerItem = 0; // FIXME:
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
I found that sometimes the `MDTabBar` items were sometimes scrolling even if there was plenty of space. I've replaced the hardcoded constants (12 for iPhone, 24 for iPad) with the property `horizontalPaddingPerItem`. It defaults to the hardcoded values, so current users should not notice any change.

Let me know if you have any questions! Thanks.