### PR TITLE
getSegmentList sorts before subviews are laid out

### DIFF
--- a/iOSUILib/iOSUILib/MDTabBar.m
+++ b/iOSUILib/iOSUILib/MDTabBar.m
@@ -273,6 +273,10 @@
   // subviews of UISegmentedControl.
   // May break in iOS updates.
 
+  // Sorting may fail if there are segments that haven't been laid out yet
+  // (e.g. two segments w/ origin.x == 0), so we do so now.
+  [self layoutIfNeeded];
+
   NSMutableArray *segments =
       [NSMutableArray arrayWithCapacity:self.numberOfSegments];
   for (UIView *view in self.subviews) {


### PR DESCRIPTION
I ran into an issue when selecting a tab where the indicator would go under the wrong tab if the tab bar is updated while the view is offscreen. It turned out we were implicitly depending on the segments having been laid out before calling `getSegmentList`, but this was not the case (the new tab had an incorrect frame).

Calling `layoutIfNeeded` at the beginning of `getSegmentList` before collecting and sorting the segments forces them to be laid out as expected.