### PR TITLE
Fixes bug where slider tick marks color cannot be set

### DIFF
--- a/iOSUILib/iOSUILib/MDSlider.m
+++ b/iOSUILib/iOSUILib/MDSlider.m
@@ -501,6 +501,11 @@
   [self updateColors];
 }
 
+- (void)setTickMarksColor:(UIColor *)tickMarksColor {
+    _tickMarksColor = tickMarksColor;
+    [tickMarksView setTickColor:_tickMarksColor];
+}
+
 - (void)setDisabledColor:(UIColor *)disabledColor {
   _disabledColor = disabledColor;
   [self updateColors];

--- a/iOSUILibDemo/SliderViewController.xib
+++ b/iOSUILibDemo/SliderViewController.xib
@@ -91,6 +91,9 @@
                                     <real key="value" value="9"/>
                                 </userDefinedRuntimeAttribute>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="enabledValueLabel" value="YES"/>
+                                <userDefinedRuntimeAttribute type="color" keyPath="tickMarksColor">
+                                    <color key="value" red="1" green="0.041036519703868346" blue="0.010226881207028415" alpha="1" colorSpace="calibratedRGB"/>
+                                </userDefinedRuntimeAttribute>
                             </userDefinedRuntimeAttributes>
                             <variation key="default">
                                 <mask key="constraints">


### PR DESCRIPTION
Added missing `setTickMarksColor` method from `MDSlider.m`. Updated demo to show custom tick marks color.