### PR TITLE
fixed animation bug

### DIFF
--- a/iOSUILib/iOSUILib/MDSnackbar.m
+++ b/iOSUILib/iOSUILib/MDSnackbar.m
@@ -361,7 +361,7 @@ MDSnackbarManger *snackbarManagerInstance;
 }
 
 - (void)dismiss {
-  if (!_isShowing || isAnimating)
+  if (!_isShowing)
     return;
   isAnimating = true;
   [NSObject cancelPreviousPerformRequestsWithTarget:self

--- a/iOSUILibDemo.xcodeproj/project.xcworkspace/xcshareddata/iOSUILibDemo.xcscmblueprint
+++ b/iOSUILibDemo.xcodeproj/project.xcworkspace/xcshareddata/iOSUILibDemo.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "4C26C3EDBF2E1880D69EC96EB92121A2836BA66F",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "4C26C3EDBF2E1880D69EC96EB92121A2836BA66F" : 0,
+    "E4DA94A476D7E1D81EA74108304A0AD3EB0D8E3E" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "01B61F17-E71A-45C7-8F7D-97A21A399346",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "4C26C3EDBF2E1880D69EC96EB92121A2836BA66F" : "Material-Controls-For-iOS",
+    "E4DA94A476D7E1D81EA74108304A0AD3EB0D8E3E" : ""
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "iOSUILibDemo",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "iOSUILibDemo.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/fpt-software\/Material-Controls-For-iOS.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "4C26C3EDBF2E1880D69EC96EB92121A2836BA66F"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/avatech-inc\/consumer-ios.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "E4DA94A476D7E1D81EA74108304A0AD3EB0D8E3E"
+    }
+  ]
+}


### PR DESCRIPTION
I removed a check of the isAnimating boolean that was preventing the snackbar from being dismissed if a dismiss call was made while the show animation was still happening. This caused a bug where the snackbar was not dismissed until the end of the timeout. I have tested that this works fine if dismiss is called while the snackbar show animation is happening.