### PR TITLE
Snackbar modifications to make width customizable

### DIFF
--- a/iOSUILib/iOSUILib/MDSnackbar.h
+++ b/iOSUILib/iOSUILib/MDSnackbar.h
@@ -48,11 +48,12 @@ IB_DESIGNABLE
 @property(nonatomic) double bottomPadding;
 @property(nonatomic) BOOL swipeable;
 @property(nonatomic) BOOL multiline;
+@property(nonatomic) CGFloat maxWidth;
 @property(nonatomic, readonly) BOOL isShowing;
 
 - (instancetype)initWithText:(NSString *)text actionTitle:(NSString *)action;
 - (instancetype)initWithText:(NSString *)text
-                 actionTitle:(NSString *)action
+                 actionTitle:(nullable NSString *)action
                     duration:(double)duration;
 
 - (void)show;

--- a/iOSUILib/iOSUILib/MDSnackbar.m
+++ b/iOSUILib/iOSUILib/MDSnackbar.m
@@ -31,7 +31,7 @@
 #define kMDLargePadding 24
 #define kMDCornerRadius 2
 #define kMDMinWidth 288
-#define kMDMaxWidth 568
+#define kMDDefaultMaxWidth 568
 
 @interface MDSnackbarManger : NSObject
 
@@ -58,6 +58,7 @@ MDSnackbarManger *snackbarManagerInstance;
 - (instancetype)init {
   if (self = [super init]) {
     [self createContent];
+    self.maxWidth = kMDDefaultMaxWidth;
   }
   return self;
 }
@@ -67,6 +68,7 @@ MDSnackbarManger *snackbarManagerInstance;
     [self createContent];
     self.text = text;
     self.actionTitle = action;
+    self.maxWidth = kMDDefaultMaxWidth;
   }
   return self;
 }
@@ -79,6 +81,7 @@ MDSnackbarManger *snackbarManagerInstance;
     self.text = text;
     self.actionTitle = action;
     self.duration = duration;
+    self.maxWidth = kMDDefaultMaxWidth;
   }
   return self;
 }
@@ -201,7 +204,7 @@ MDSnackbarManger *snackbarManagerInstance;
                                         toItem:nil
                                      attribute:NSLayoutAttributeNotAnAttribute
                                     multiplier:1.0
-                                      constant:kMDMaxWidth];
+                                      constant:self.maxWidth];
     [self addConstraint:maxWidthConstraint];
   }
 }


### PR DESCRIPTION
Allows snackbar width to be customizable (as the default is pretty narrow for landscape iPad).