### PR TITLE
Fixed retain cicle between MDRippleLayer and MDTableViewCell. Fixed n…

### DIFF
--- a/MaterialControls/MaterialControls/MDRippleLayer.m
+++ b/MaterialControls/MaterialControls/MDRippleLayer.m
@@ -36,7 +36,7 @@
 @interface MDRippleLayer () <MDTouchGestureRecognizerDelegate, CAAnimationDelegate,
                              UIGestureRecognizerDelegate>
 
-@property CALayer *superLayer;
+@property (weak) CALayer *superLayer;
 @property CAShapeLayer *rippleLayer;
 @property CAShapeLayer *backgroundLayer;
 @property CAShapeLayer *maskLayer;
@@ -124,6 +124,12 @@
   } else if ([keyPath isEqualToString:@"cornerRadius"]) {
     [self setMaskLayerCornerRadius:_superLayer.cornerRadius];
   }
+}
+
+- (void)removeFromSuperlayer {
+  [super removeFromSuperlayer];
+  [_superLayer removeObserver:self forKeyPath:@"bounds"];
+  [_superLayer removeObserver:self forKeyPath:@"cornerRadius"];
 }
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {

--- a/MaterialControls/MaterialControls/MDTableViewCell.m
+++ b/MaterialControls/MaterialControls/MDTableViewCell.m
@@ -67,6 +67,10 @@
 }
 
 - (void)initLayer {
+  if (_mdLayer) {
+    [_mdLayer removeFromSuperlayer];
+    _mdLayer = nil;
+  }
   if (!_rippleColor)
     _rippleColor = [UIColor colorWithWhite:0.5 alpha:1];
 


### PR DESCRIPTION
You had a retain cycle with the superLayer property. By default it is strong, so the superlayer adds MDRippleLayer as a sublayer. It means that it retains it via the array of sublayers. So, the retain cycle occurs.

Secondly, I've noticed that new MDRipple layers are added constantly when the tableview is scrolled. So, I suggest removing the previously created ripple layer in a cell before adding the new one.
