### PR TITLE
Remove finished check from snackbar animation

### DIFF
--- a/MaterialControls/MaterialControls/MDSnackbar.m
+++ b/MaterialControls/MaterialControls/MDSnackbar.m
@@ -297,17 +297,15 @@ MDSnackbarManger *snackbarManagerInstance;
         [rootView layoutIfNeeded];
       }
       completion:^(BOOL finished) {
-        if (finished) {
-          isAnimating = false;
-          [self performDelegateAction:@selector(snackbarDidAppear:)];
+        isAnimating = false;
+        [self performDelegateAction:@selector(snackbarDidAppear:)];
 
-            if(_duration > 0)
+        if(_duration > 0)
           [self performSelector:@selector(dismiss)
                      withObject:nil
                      afterDelay:_duration];
 
-          actionButton.enabled = true;
-        }
+        actionButton.enabled = true;
       }];
 }
 
@@ -385,14 +383,12 @@ MDSnackbarManger *snackbarManagerInstance;
         [rootView layoutIfNeeded];
       }
       completion:^(BOOL finished) {
-        if (finished) {
-          isAnimating = false;
-          [self performDelegateAction:@selector(snackbarDidDisappear:)];
-          [self removeFromSuperview];
-          [textLabel removeFromSuperview];
-          [actionButton removeFromSuperview];
-          _isShowing = false;
-        }
+        isAnimating = false;
+        [self performDelegateAction:@selector(snackbarDidDisappear:)];
+        [self removeFromSuperview];
+        [textLabel removeFromSuperview];
+        [actionButton removeFromSuperview];
+        _isShowing = false;
       }];
 }
 


### PR DESCRIPTION
I was having issues with the snackbar dismissing/showing properly when the animation was canceled, either by backgrounding the app or potentially otherwise by overlapping animations.

The problem is that if the animation is canceled, the state isn't updated and delegate methods aren't run, resulting in `isAnimating` and `isShowing` to not be recorded properly, which messes up the dismiss/show logic of subsequent snackbar showings.

This solution seems to work for me and I can't think of any downsides, because I believe that the post-animation property setting and delegate calls still need to be called even if the animation is canceled (which results in `finished == NO`).

But if my understanding is incorrect and/or I'm not thinking of use cases where this was considered, please let me know.