### PR TITLE
Fix for label text color on load

### DIFF
--- a/MaterialControls/MaterialControls/MDTextField.m
+++ b/MaterialControls/MaterialControls/MDTextField.m
@@ -1054,10 +1054,9 @@
 }
 
 - (void)setViewState:(MDTextFieldViewState)state {
-  if (_viewState != state) {
-    _viewState = state;
+  _viewState = state;
 
-    switch (state) {
+  switch (state) {
     case MDTextFieldViewStateNormal:
       if (!_fullWidth) {
         [_dividerHolder setState:MDTextFieldViewStateNormal];
@@ -1090,7 +1089,6 @@
 
     default:
       break;
-    }
   }
 }
 


### PR DESCRIPTION
I was trying to change the label color in my storyboard, but noticed that it didn't update from the default until the text view actually lost focus.

Looks like what's happening is the interface builder setting isn't set by the time initWithCoder fires, and later on when setNormalColor gets called, setViewState ultimately does nothing because it decides that the state hasn't changed.  Unfortunately, that's also the method responsible for updating the label color.

I've removed that check here, which causes a little more work than ideal, however currently they're necessary.