### PR TITLE
Fix: wrong divider colour for error state just after Controller loads

### DIFF
--- a/MaterialControls/MaterialControls/MDTextField.m
+++ b/MaterialControls/MaterialControls/MDTextField.m
@@ -166,7 +166,7 @@
   if (![_errorColor isEqual:errorColor]) {
     _errorColor = errorColor;
     if (_state == MDTextFieldViewStateError)
-      highlightLayer.strokeColor = _highlightColor.CGColor;
+      highlightLayer.strokeColor = _errorColor.CGColor;
   }
 }
 
@@ -298,7 +298,12 @@
   [highlightLayer setPath:linePath.CGPath];
   [highlightLayer setLineWidth:_highlightHeight];
   [highlightLayer setFillColor:[[UIColor clearColor] CGColor]];
-  [highlightLayer setStrokeColor:[_highlightColor CGColor]];
+  // use stroke color depending on current state
+    if (_state == MDTextFieldViewStateError) {
+        [highlightLayer setStrokeColor:[_errorColor CGColor]];
+    } else {
+        [highlightLayer setStrokeColor:[_highlightColor CGColor]];
+    }
 }
 
 - (void)drawDashedLineDivider {


### PR DESCRIPTION
1. The methods -drawLineDivider of DividerView class overrides the error stroke colour of the highlightLayer even if the control is in error state.
2. The method -setErrorColor: method of DividerView class wrongly sets the stroke colour as highlightColor in error state.