### PR TITLE
use nfloat for sliders

### DIFF
--- a/MaterialControls.Xamarin.Binding/ApiDefinition.cs
+++ b/MaterialControls.Xamarin.Binding/ApiDefinition.cs
@@ -423,15 +423,15 @@ namespace MaterialControls
 
 		// @property (nonatomic) float value;
 		[Export("value")]
-		float Value { get; set; }
+		nfloat Value { get; set; }
 
 		// @property (nonatomic) float maximumValue;
 		[Export("maximumValue")]
-		float MaximumValue { get; set; }
+		nfloat MaximumValue { get; set; }
 
 		// @property (nonatomic) float minimumValue;
 		[Export("minimumValue")]
-		float MinimumValue { get; set; }
+		nfloat MinimumValue { get; set; }
 
 		// @property (nonatomic) UIColor * thumbOnColor;
 		[Export("thumbOnColor")]
@@ -471,7 +471,7 @@ namespace MaterialControls
 
 		// @property (nonatomic) float step;
 		[Export("step")]
-		float Step { get; set; }
+		nfloat Step { get; set; }
 
 		// @property (nonatomic) BOOL enabledValueLabel;
 		[Export("enabledValueLabel")]


### PR DESCRIPTION
I had problems using the MDSlider control in Xamarin. The "value" property wasn't respecting its actual value that was set. Accessing the value property would always return a single value. Switching the value, min value & max value properties to "nfloat" instead of "float" appears to fix the issue